### PR TITLE
To avoid overlaping of push and pull actions around 12:00 UTC

### DIFF
--- a/OCHP-direct.md
+++ b/OCHP-direct.md
@@ -341,8 +341,8 @@ On day `N` do:
 
  1. *At 00:30 UTC:* Invalidate/delete all tokens of day `N-1`.
  2. Generate new own token for day `N+1`.
- 3. *Before 12:00 UTC:* Send/upload own token for day `N+1`.
- 4. *After 12:00 UTC:* Fetch/download partner's tokens for day `N+1`.
+ 3. *Before 11:50 UTC:* Send/upload own token for day `N+1`.
+ 4. *After 12:10 UTC:* Fetch/download partner's tokens for day `N+1`.
  5. Generate token combinations for day `N+1` from own and partner's 
     tokens. Here `AB2`.
  6. *At 23:50 UTC:* Make token combinations for day `N+1` valid.

--- a/OCHP-direct.md
+++ b/OCHP-direct.md
@@ -440,7 +440,7 @@ systems.
 
 The following figure gives an overview of the communication. After step
 (3) follows the CDR exchange process as described in OCHP. Calls from
-the operator to the provider (_italic_) are covered in the advanced use
+the operator to the provider are covered in the advanced use
 cases.
 
 ![Figure OCHP direct basic process](media/OCHPdirectProcess-1.png "OCHP direct basic process")


### PR DESCRIPTION
Pushes and pulls close to 12:00 UTC in reality could have unpredictable time lag (e.g. network lag). One pull could finish before some push.
My opinion is that process for exchanging partners tokens must have some time gap between pushes and pulls.
Proposition for time lag (silence time) is 20 min.
One reason for overlapping of exchange actions might be untuned partner endpoint clock with UTC.
