### PR TITLE
Fixed Type in ConnectorStandard definition

### DIFF
--- a/OCHP.md
+++ b/OCHP.md
@@ -140,7 +140,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         - [RelatedResourceClass *enum*](#relatedresourceclass-enum)
         - [GeoPointType *class*](#geopointtype-class)
         - [AdditionalGeoPointType *class*](#additionalgeopointtype-class)
-        - [ConnectorStandard *enum*](#connectorstandard-enum)
+        - [ConnectorStandardType *enum*](#connectorstandardtype-enum)
         - [ConnectorFormat *enum*](#connectorformat-enum)
         - [ConnectorType *class*](#connectortype-class)
         - [AuthMethodType *enum*](#authmethodtype-enum)
@@ -1744,7 +1744,7 @@ Where the type-enum can be one of the following choices:
  other       |  Other relevant point. Name recommended.
 
 
-### ConnectorStandard *enum*
+### ConnectorStandardType *enum*
 
 The socket or plug standard of the charging point.
 


### PR DESCRIPTION
The definition of ConnectorType, field: connectorStandard is defined as being of the type: ConnectorStandardType but there was only a type: ConnectorStandard in OCHP. I think that is a typo.
I hope I have fixed it this way.